### PR TITLE
Add isLayout property to getSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `isLayout` property to getSchema of ProductKit component.
 
 ## [0.1.0] - 2018-7-6
-
 ### Added
 - PropTypes validation according to graphql data.
 - Initial implementation

--- a/react/ProductKit.js
+++ b/react/ProductKit.js
@@ -36,25 +36,30 @@ class ProductKit extends Component {
           type: 'boolean',
           title: 'editor.productKit.showListPrice',
           default: true,
+          isLayout: true,
         },
         showLabels: {
           type: 'boolean',
           title: 'editor.productKit.showLabels',
           default: false,
+          isLayout: true,
         },
         showInstallments: {
           type: 'boolean',
           title: 'editor.productKit.showInstallments',
           default: false,
+          isLayout: true,
         },
         showBadge: {
           type: 'boolean',
           title: 'editor.productKit.showBadge',
           default: false,
+          isLayout: true,
         },
         badgeText: showBadge ? {
           type: 'string',
           title: 'editor.productKit.badgeText',
+          isLayout: false,
         } : {},
       },
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add isLayout property to getSchema of ProductKit.

#### What problem is this solving?
Segregate layout schema props and content schema props.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
