### PR TITLE
Fix Content Loader on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Content loader on Firefox.
 
 ## [0.1.5] - 2018-08-10
 ### Added

--- a/react/ProductKit.js
+++ b/react/ProductKit.js
@@ -1,13 +1,13 @@
-import './global.css';
+import './global.css'
 
-import { path } from 'ramda';
-import React, { Component, Fragment } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { path } from 'ramda'
+import React, { Component, Fragment } from 'react'
+import { FormattedMessage } from 'react-intl'
 
-import ProductKitDetails from './ProductKitDetails';
-import ProductKitItem from './ProductKitItem';
-import ProductKitPropTypes from './productKitPropTypes';
-import ProductKitSeparator from './ProductKitSeparator';
+import ProductKitDetails from './ProductKitDetails'
+import ProductKitItem from './ProductKitItem'
+import ProductKitPropTypes from './productKitPropTypes'
+import ProductKitSeparator from './ProductKitSeparator'
 
 const MAX_ITEMS = 3
 const ITEMS_CONTENT_LOADER = 2

--- a/react/ProductKitDetails.js
+++ b/react/ProductKitDetails.js
@@ -1,9 +1,9 @@
-import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
-import { FormattedMessage } from 'react-intl';
-import { BuyButton, ProductPrice } from 'vtex.store-components';
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { BuyButton, ProductPrice } from 'vtex.store-components'
 
-import propTypes from './productKitItemPropTypes';
+import propTypes from './productKitItemPropTypes'
 
 const priceLoaderStyles = {
   'vtex-price-list__container--loader': {

--- a/react/ProductKitDetails.js
+++ b/react/ProductKitDetails.js
@@ -1,9 +1,21 @@
-import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
-import { FormattedMessage } from 'react-intl'
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { BuyButton, ProductPrice } from 'vtex.store-components';
 
-import propTypes from './productKitItemPropTypes'
-import { ProductPrice, BuyButton } from 'vtex.store-components'
+import propTypes from './productKitItemPropTypes';
+
+const priceLoaderStyles = {
+  'vtex-price-list__container--loader': {
+    height: 0,
+  },
+  'vtex-price-installments--loader': {
+    height: 0,
+  },
+  'vtex-price-selling--loader': {
+    height: '1.5em',
+  },
+}
 
 /**
  * Product Kit Details component.
@@ -56,6 +68,7 @@ export default class ProductKitDetails extends PureComponent {
         />
         <div className="pv4">
           <ProductPrice
+            styles={priceLoaderStyles}
             sellingPrice={!loading ? this.calculatePrice(kitProducts) : null}
             showInstallments={false}
             showListPrice={false}


### PR DESCRIPTION
#### What is the purpose of this pull request?
On Firefox, it was not possible to determine the SVG's style via CSS/Style prop. So, what works on Chrome and Safari, doesn't work on Firefox. To work in all browsers, the found solution was pass every style via elements properties.

#### What problem is this solving?
Content Loaders not rendering on Firefox.

#### How should this be manually tested?

[Access the workspace](https://estacio--storecomponents.myvtex.com/)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/44040777-787f4dd0-9ef2-11e8-8265-d73fda3fe3b7.png)



#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
