### PR TITLE
Add default padding matching the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Default padding matching the page.
 
 ## [0.3.0] - 2018-09-05
 ### Added

--- a/react/ProductKit.js
+++ b/react/ProductKit.js
@@ -150,7 +150,7 @@ class ProductKit extends Component {
           .map(this.prepareProductKit)
 
     return (
-      <div className="vtex-product-kit flex flex-column items-center justify-center mb7">
+      <div className="vtex-product-kit vtex-page-padding flex flex-column items-center justify-center mb7">
         <h1 className="pv3 ph3">
           <FormattedMessage id="productKit.buyTogether" />
         </h1>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add default padding to match the page's padding.

#### What problem is this solving?

Product Kit had no padding.

#### How should this be manually tested?

[Access the worskpace](https://padding--storecomponents.myvtex.com/porsche-911/p) and change the window size.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/45314314-c5a31d00-b507-11e8-9ebe-27e3aa9bd56e.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
