### PR TITLE
Remove content loader of ProductKit component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- no content loader.
 
 ## [0.4.0] - 2018-09-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.1] - 2018-10-05
 ### Fixed
 - Remove content loader.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- remove content loader.
+- Remove content loader.
 
 ## [0.4.0] - 2018-09-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- no content loader.
+- remove content loader.
 
 ## [0.4.0] - 2018-09-26
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-kit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "title": "VTEX Product Kit",
   "description": "The VTEX Product Kit which display a list of Products as a kit",
   "defaultLocale": "pt-BR",

--- a/react/ProductKit.js
+++ b/react/ProductKit.js
@@ -100,20 +100,17 @@ export default class ProductKit extends Component {
       showLabels,
       showListPrice,
       showInstallments,
-      productQuery: { product },
+      productQuery: { product, loading },
     } = this.props
 
     const benefits = path(['benefits'], product)
 
     /** The product does not have any Kit associated with it, in this case
      *  the ProductKitContent should not be rendered */
-    if (benefits && !benefits.length) return null
+    if (loading || (benefits && !benefits.length)) return null
 
     /** Shown and Hiden items */
     const { shownItems, hidenItems } = this.state
-
-    /** The component is loading if the shown items has the default content */
-    const loading = equals(shownItems, DEFAULT_VISIBLE_ITEMS)
 
     /** Allow item swap only if there's hiden items */
     const allowSwap = hidenItems.length > 0
@@ -121,7 +118,6 @@ export default class ProductKit extends Component {
     return (
       <div className="vtex-page-padding">
         <ProductKitContent
-          loading={loading}
           allowSwap={allowSwap}
           itemsKit={shownItems}
           viewOptions={{

--- a/react/components/ProductKitContent.js
+++ b/react/components/ProductKitContent.js
@@ -11,7 +11,7 @@ import ProductKitItem from './ProductKitItem'
  */
 export default class ProductKitContent extends Component {
   render() {
-    const { itemsKit, allowSwap, viewOptions, loading, onItemSwap } = this.props
+    const { itemsKit, allowSwap, viewOptions, onItemSwap } = this.props
 
     return (
       <div className="vtex-product-kit flex flex-column items-center justify-center mb7">
@@ -21,23 +21,21 @@ export default class ProductKitContent extends Component {
         <div className="flex flex-column flex-wrap-l flex-row-l items-center justify-center">
           {itemsKit.map((item, index) => (
             <Fragment key={index}>
-              {index > 0 &&
-                !loading && (
-                  <div className="flex items-center justify-center mh4 mv4 b white bg-action-primary h2 w2 br-100">
-                    <span>&#43;</span>
-                  </div>
-                )}
+              {index > 0 && (
+                <div className="flex items-center justify-center mh4 mv4 b white bg-action-primary h2 w2 br-100">
+                  <span>&#43;</span>
+                </div>
+              )}
               <ProductKitItem
                 item={item}
                 itemIndex={index}
-                loading={loading}
                 allowSwap={allowSwap}
                 onItemSwap={onItemSwap}
                 viewOptions={viewOptions}
               />
             </Fragment>
           ))}
-          <ProductKitDetails loading={loading} items={itemsKit} />
+          <ProductKitDetails items={itemsKit} />
         </div>
       </div>
     )

--- a/react/components/ProductKitItem.js
+++ b/react/components/ProductKitItem.js
@@ -37,9 +37,9 @@ export default class ProductKitItem extends Component {
         ) : (
           <div className="relative dib">
             <div
-              className="flex itemsKIt-center absolute left-0 white pointer br1 z-999 bg-action-primary"
+              className="flex items-center absolute left-0 white pointer br1 z-999 bg-action-primary"
               onClick={() => onitemsKItwap(itemIndex)}>
-              <div className="vtex-product-kit__item-swap-button h1 flex flex-row itemsKIt-center mh3 mv3">
+              <div className="vtex-product-kit__item-swap-button h1 flex flex-row items-center mh3 mv3">
                 <img className="w1 h1" src={swapIcon} />
                 <div className="dn ml3">
                   <FormattedMessage id="productKit.swapItem" />

--- a/react/components/ProductKitItem.js
+++ b/react/components/ProductKitItem.js
@@ -22,13 +22,7 @@ export default class ProductKitItem extends Component {
   }
 
   render() {
-    const {
-      item,
-      itemIndex,
-      allowSwap,
-      onitemsKItwap,
-      viewOptions,
-    } = this.props
+    const { item, itemIndex, allowSwap, onItemSwap, viewOptions } = this.props
 
     return (
       <div className="vtex-product-kit__item">
@@ -38,7 +32,7 @@ export default class ProductKitItem extends Component {
           <div className="relative dib">
             <div
               className="flex items-center absolute left-0 white pointer br1 z-999 bg-action-primary"
-              onClick={() => onitemsKItwap(itemIndex)}>
+              onClick={() => onItemSwap(itemIndex)}>
               <div className="vtex-product-kit__item-swap-button h1 flex flex-row items-center mh3 mv3">
                 <img className="w1 h1" src={swapIcon} />
                 <div className="dn ml3">

--- a/react/components/ProductKitItem.js
+++ b/react/components/ProductKitItem.js
@@ -17,8 +17,6 @@ export default class ProductKitItem extends Component {
     item: ProductKitItemProps.product,
     /** Allow item swap flag */
     allowSwap: PropTypes.bool,
-    /** Is component loading flag */
-    loading: PropTypes.bool,
     /** Props of Product Summary */
     viewOptions: PropTypes.any,
   }
@@ -28,19 +26,20 @@ export default class ProductKitItem extends Component {
       item,
       itemIndex,
       allowSwap,
-      loading,
-      onItemSwap,
+      onitemsKItwap,
       viewOptions,
     } = this.props
 
     return (
       <div className="vtex-product-kit__item">
-        {!loading && allowSwap ? (
+        {!allowSwap ? (
+          <ProductSummary product={item} {...viewOptions} hideBuyButton />
+        ) : (
           <div className="relative dib">
             <div
-              className="flex items-center absolute left-0 white pointer br1 z-999 bg-action-primary"
-              onClick={() => onItemSwap(itemIndex)}>
-              <div className="vtex-product-kit__item-swap-button h1 flex flex-row items-center mh3 mv3">
+              className="flex itemsKIt-center absolute left-0 white pointer br1 z-999 bg-action-primary"
+              onClick={() => onitemsKItwap(itemIndex)}>
+              <div className="vtex-product-kit__item-swap-button h1 flex flex-row itemsKIt-center mh3 mv3">
                 <img className="w1 h1" src={swapIcon} />
                 <div className="dn ml3">
                   <FormattedMessage id="productKit.swapItem" />
@@ -49,8 +48,6 @@ export default class ProductKitItem extends Component {
             </div>
             <ProductSummary product={item} {...viewOptions} hideBuyButton />
           </div>
-        ) : (
-          <ProductSummary product={item} {...viewOptions} hideBuyButton />
         )}
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the content loader of ProductKit component.

#### What problem is this solving?
The content loader of ProductKit was being showed even when there is no Kit of Products for a specific Product. The decision was to not show a content loader for this component and let the component arises in the screen when it totally finish the graphql query and if it has a Kit of Products in the query.

#### Screenshots or example usage
<a href="https://productkit--storecomponents.myvtex.com/ninja-300/p">Click here to access the product page of a product that has a Kit associated with it</a>

<a href="https://productkit--storecomponents.myvtex.com/motorola-moto-x4/p">Click here to access the product page of a product that hasn't a Kit associated with it</a>

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
