### PR TITLE
Update BuyButton items props to use the Minicart's optimistic strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.0] - 2019-02-12
 ### Added
 - Add the optimistic minicart strategy props to the `BuyButton`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add the optimistic minicart strategy props to the `BuyButton`.
 
 ## [1.7.0] - 2019-02-04
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-kit",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "title": "VTEX Product Kit",
   "description": "The VTEX Product Kit which display a list of Products as a kit",
   "defaultLocale": "pt-BR",

--- a/react/components/ProductKitDetails.js
+++ b/react/components/ProductKitDetails.js
@@ -55,12 +55,9 @@ export default class ProductKitDetails extends Component {
       price: path(['sku', 'seller', 'commertialOffer', 'Price'], item),
       variant: item.sku.name,
       brand: item.brand,
-
-      /* Optimistic props */
       detailUrl: `/${item.linkText}/p`,
       imageUrl: path(['sku', 'image', 'imageUrl'], item),
       listPrice: path(['sku', 'seller', 'commertialOffer', 'ListPrice'], item),
-      /* End Optimistic props */
     }))
   }
 

--- a/react/components/ProductKitDetails.js
+++ b/react/components/ProductKitDetails.js
@@ -55,6 +55,12 @@ export default class ProductKitDetails extends Component {
       price: path(['sku', 'seller', 'commertialOffer', 'Price'], item),
       variant: item.sku.name,
       brand: item.brand,
+
+      /* Optimistic props */
+      detailUrl: `/${item.linkText}/p`,
+      imageUrl: path(['sku', 'image', 'imageUrl'], item),
+      listPrice: path(['sku', 'seller', 'commertialOffer', 'ListPrice'], item),
+      /* End Optimistic props */
     }))
   }
 


### PR DESCRIPTION
**Related to vtex-apps/minicart#93**

#### What is the purpose of this pull request?

Update the buy-button items props so the product-summary can use the minicart's optimistic strategy.

#### What problem is this solving?

Outdated props.

#### How should this be manually tested?

[Access the workspace](https://offline--storecomponents.myvtex.com)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
